### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ up to date
 
 ## Installation
 
-`GO111MODULE=on go get -u github.com/neutralinsomniac/obsdpkgup/cmd/obsdpkgup`
+`go install github.com/neutralinsomniac/obsdpkgup/cmd/obsdpkgup@latest`
 
 ## Usage
 


### PR DESCRIPTION
Module mode is assumed by default and 'go get' for installing
executables is deprecated or not possible in newer Go versions.  Use
'go install' instead.